### PR TITLE
unmarshaling fixes

### DIFF
--- a/api/btc_signature_kind.go
+++ b/api/btc_signature_kind.go
@@ -22,7 +22,7 @@ func (dst *BtcSignatureKind) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
 	// try to unmarshal data into BtcSignatureKindOneOf
-	err = newStrictDecoder(data).Decode(&dst.BtcSignatureKindOneOf)
+	err = NewStrictDecoder(data).Decode(&dst.BtcSignatureKindOneOf)
 	if err == nil {
 		jsonBtcSignatureKindOneOf, _ := json.Marshal(dst.BtcSignatureKindOneOf)
 		if string(jsonBtcSignatureKindOneOf) == "{}" { // empty struct

--- a/api/client.go
+++ b/api/client.go
@@ -115,13 +115,6 @@ func reportError(format string, a ...interface{}) error {
 	return fmt.Errorf(format, a...)
 }
 
-// A wrapper for strict JSON decoding
-func NewStrictDecoder(data []byte) *json.Decoder {
-	dec := json.NewDecoder(bytes.NewBuffer(data))
-	dec.DisallowUnknownFields()
-	return dec
-}
-
 // Set request body from an interface{}
 func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err error) {
 	if bodyBuf == nil {

--- a/api/policy_error_code.go
+++ b/api/policy_error_code.go
@@ -30,7 +30,7 @@ func (dst *PolicyErrorCode) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
 	// try to unmarshal data into EvmTxDepositErrorCode
-	err = newStrictDecoder(data).Decode(&dst.EvmTxDepositErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.EvmTxDepositErrorCode)
 	if err == nil {
 		jsonEvmTxDepositErrorCode, _ := json.Marshal(dst.EvmTxDepositErrorCode)
 		if string(jsonEvmTxDepositErrorCode) == "{}" { // empty struct
@@ -43,7 +43,7 @@ func (dst *PolicyErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into PolicyErrorOwnCodes
-	err = newStrictDecoder(data).Decode(&dst.PolicyErrorOwnCodes)
+	err = NewStrictDecoder(data).Decode(&dst.PolicyErrorOwnCodes)
 	if err == nil {
 		jsonPolicyErrorOwnCodes, _ := json.Marshal(dst.PolicyErrorOwnCodes)
 		if string(jsonPolicyErrorOwnCodes) == "{}" { // empty struct

--- a/api/precondition_error_code.go
+++ b/api/precondition_error_code.go
@@ -30,7 +30,7 @@ func (dst *PreconditionErrorCode) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
 	// try to unmarshal data into PolicyErrorCode
-	err = newStrictDecoder(data).Decode(&dst.PolicyErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.PolicyErrorCode)
 	if err == nil {
 		jsonPolicyErrorCode, _ := json.Marshal(dst.PolicyErrorCode)
 		if string(jsonPolicyErrorCode) == "{}" { // empty struct
@@ -43,7 +43,7 @@ func (dst *PreconditionErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into PreconditionErrorOwnCodes
-	err = newStrictDecoder(data).Decode(&dst.PreconditionErrorOwnCodes)
+	err = NewStrictDecoder(data).Decode(&dst.PreconditionErrorOwnCodes)
 	if err == nil {
 		jsonPreconditionErrorOwnCodes, _ := json.Marshal(dst.PreconditionErrorOwnCodes)
 		if string(jsonPreconditionErrorOwnCodes) == "{}" { // empty struct

--- a/api/prev_outputs.go
+++ b/api/prev_outputs.go
@@ -30,7 +30,7 @@ func (dst *PrevOutputs) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
 	// try to unmarshal data into PrevOutputsOneOf
-	err = newStrictDecoder(data).Decode(&dst.PrevOutputsOneOf)
+	err = NewStrictDecoder(data).Decode(&dst.PrevOutputsOneOf)
 	if err == nil {
 		jsonPrevOutputsOneOf, _ := json.Marshal(dst.PrevOutputsOneOf)
 		if string(jsonPrevOutputsOneOf) == "{}" { // empty struct
@@ -43,7 +43,7 @@ func (dst *PrevOutputs) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into PrevOutputsOneOf1
-	err = newStrictDecoder(data).Decode(&dst.PrevOutputsOneOf1)
+	err = NewStrictDecoder(data).Decode(&dst.PrevOutputsOneOf1)
 	if err == nil {
 		jsonPrevOutputsOneOf1, _ := json.Marshal(dst.PrevOutputsOneOf1)
 		if string(jsonPrevOutputsOneOf1) == "{}" { // empty struct

--- a/api/signer_error_code.go
+++ b/api/signer_error_code.go
@@ -86,7 +86,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
 	// try to unmarshal data into AcceptedValueCode
-	err = newStrictDecoder(data).Decode(&dst.AcceptedValueCode)
+	err = NewStrictDecoder(data).Decode(&dst.AcceptedValueCode)
 	if err == nil {
 		jsonAcceptedValueCode, _ := json.Marshal(dst.AcceptedValueCode)
 		if string(jsonAcceptedValueCode) == "{}" { // empty struct
@@ -99,7 +99,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into BadGatewayErrorCode
-	err = newStrictDecoder(data).Decode(&dst.BadGatewayErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.BadGatewayErrorCode)
 	if err == nil {
 		jsonBadGatewayErrorCode, _ := json.Marshal(dst.BadGatewayErrorCode)
 		if string(jsonBadGatewayErrorCode) == "{}" { // empty struct
@@ -112,7 +112,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into BadRequestErrorCode
-	err = newStrictDecoder(data).Decode(&dst.BadRequestErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.BadRequestErrorCode)
 	if err == nil {
 		jsonBadRequestErrorCode, _ := json.Marshal(dst.BadRequestErrorCode)
 		if string(jsonBadRequestErrorCode) == "{}" { // empty struct
@@ -125,7 +125,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into ForbiddenErrorCode
-	err = newStrictDecoder(data).Decode(&dst.ForbiddenErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.ForbiddenErrorCode)
 	if err == nil {
 		jsonForbiddenErrorCode, _ := json.Marshal(dst.ForbiddenErrorCode)
 		if string(jsonForbiddenErrorCode) == "{}" { // empty struct
@@ -138,7 +138,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into InternalErrorCode
-	err = newStrictDecoder(data).Decode(&dst.InternalErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.InternalErrorCode)
 	if err == nil {
 		jsonInternalErrorCode, _ := json.Marshal(dst.InternalErrorCode)
 		if string(jsonInternalErrorCode) == "{}" { // empty struct
@@ -151,7 +151,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into NotFoundErrorCode
-	err = newStrictDecoder(data).Decode(&dst.NotFoundErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.NotFoundErrorCode)
 	if err == nil {
 		jsonNotFoundErrorCode, _ := json.Marshal(dst.NotFoundErrorCode)
 		if string(jsonNotFoundErrorCode) == "{}" { // empty struct
@@ -164,7 +164,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into PreconditionErrorCode
-	err = newStrictDecoder(data).Decode(&dst.PreconditionErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.PreconditionErrorCode)
 	if err == nil {
 		jsonPreconditionErrorCode, _ := json.Marshal(dst.PreconditionErrorCode)
 		if string(jsonPreconditionErrorCode) == "{}" { // empty struct
@@ -177,7 +177,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into SignerErrorOwnCodes
-	err = newStrictDecoder(data).Decode(&dst.SignerErrorOwnCodes)
+	err = NewStrictDecoder(data).Decode(&dst.SignerErrorOwnCodes)
 	if err == nil {
 		jsonSignerErrorOwnCodes, _ := json.Marshal(dst.SignerErrorOwnCodes)
 		if string(jsonSignerErrorOwnCodes) == "{}" { // empty struct
@@ -190,7 +190,7 @@ func (dst *SignerErrorCode) UnmarshalJSON(data []byte) error {
 	}
 
 	// try to unmarshal data into UnauthorizedErrorCode
-	err = newStrictDecoder(data).Decode(&dst.UnauthorizedErrorCode)
+	err = NewStrictDecoder(data).Decode(&dst.UnauthorizedErrorCode)
 	if err == nil {
 		jsonUnauthorizedErrorCode, _ := json.Marshal(dst.UnauthorizedErrorCode)
 		if string(jsonUnauthorizedErrorCode) == "{}" { // empty struct

--- a/api/utils.go
+++ b/api/utils.go
@@ -319,7 +319,7 @@ func (v *NullableTime) UnmarshalJSON(src []byte) error {
 }
 
 // A wrapper for strict JSON decoding
-func newStrictDecoder(data []byte) *json.Decoder {
+func NewStrictDecoder(data []byte) *json.Decoder {
 	dec := json.NewDecoder(bytes.NewBuffer(data))
 	dec.DisallowUnknownFields()
 	return dec

--- a/api/v0/babylon_staking_request.go
+++ b/api/v0/babylon_staking_request.go
@@ -3,6 +3,7 @@ package v0
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/lombard-finance/cubesigner-sdk/api"
 )
 
@@ -39,7 +40,8 @@ func BabylonStakingWithdrawalAsBabylonStakingRequest(v *BabylonStakingWithdrawal
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *BabylonStakingRequest) UnmarshalJSON(data []byte) error {
 	var err error
-	match := 0
+	var matches []api.BabylonStakingAction
+
 	// try to unmarshal data into BabylonStakingDeposit
 	err = api.NewStrictDecoder(data).Decode(&dst.BabylonStakingDeposit)
 	if err == nil {
@@ -47,7 +49,7 @@ func (dst *BabylonStakingRequest) UnmarshalJSON(data []byte) error {
 		if string(jsonBabylonStakingDeposit) == "{}" { // empty struct
 			dst.BabylonStakingDeposit = nil
 		} else {
-			match++
+			matches = append(matches, api.DepositAction)
 		}
 	} else {
 		dst.BabylonStakingDeposit = nil
@@ -60,7 +62,7 @@ func (dst *BabylonStakingRequest) UnmarshalJSON(data []byte) error {
 		if string(jsonBabylonStakingEarlyUnbond) == "{}" { // empty struct
 			dst.BabylonStakingEarlyUnbond = nil
 		} else {
-			match++
+			matches = append(matches, api.EarlyUnbondAction)
 		}
 	} else {
 		dst.BabylonStakingEarlyUnbond = nil
@@ -73,20 +75,21 @@ func (dst *BabylonStakingRequest) UnmarshalJSON(data []byte) error {
 		if string(jsonBabylonStakingWithdrawal) == "{}" { // empty struct
 			dst.BabylonStakingWithdrawal = nil
 		} else {
-			match++
+			matches = append(matches, api.WithdrawEarlyUnbondAction)
 		}
 	} else {
 		dst.BabylonStakingWithdrawal = nil
 	}
 
-	if match > 1 { // more than 1 match
+	if len(matches) > 1 { // more than 1 match
 		// reset to nil
 		dst.BabylonStakingDeposit = nil
 		dst.BabylonStakingEarlyUnbond = nil
 		dst.BabylonStakingWithdrawal = nil
 
 		return fmt.Errorf("Data matches more than one schema in oneOf(BabylonStakingRequest)")
-	} else if match == 1 {
+	} else if len(matches) == 1 {
+		dst.Action = matches[0]
 		return nil // exactly one match
 	} else { // no match
 		return fmt.Errorf("Data failed to match schemas in oneOf(BabylonStakingRequest)")

--- a/api/v0/mfa_request_info.go
+++ b/api/v0/mfa_request_info.go
@@ -3,7 +3,7 @@ package v0
 // MfaRequestInfo struct returned for GetMfaRequest and ApproveMfaRequest
 type MfaRequestInfo struct {
 	// DateTime measured in seconds since unix epoch. A wrapper type for serialization that encodes a `SystemTime` as a `u64` representing the number of seconds since `SystemTime::UNIX_EPOCH`.
-	ExpiresAt int64 `json:"timestamp"`
+	ExpiresAt int64 `json:"expires_at"`
 	// Approval request ID.
 	Id string `json:"id"`
 	// Receipt that an MFA request was approved.

--- a/api/v0/psbt_sign_request.go
+++ b/api/v0/psbt_sign_request.go
@@ -2,6 +2,9 @@ package v0
 
 import (
 	"encoding/json"
+	"fmt"
+
+	"github.com/lombard-finance/cubesigner-sdk/api"
 )
 
 // PsbtSignRequest A request to sign a PSBT
@@ -86,15 +89,34 @@ func (o *PsbtSignRequest) SetSignAllScripts(v bool) {
 	o.SignAllScripts = &v
 }
 
-func (o PsbtSignRequest) MarshalJSON() ([]byte, error) {
+func (src PsbtSignRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["psbt"] = o.Psbt
+
+	toSerialize["psbt"] = src.Psbt
+
+	if src.SignAllScripts != nil {
+		toSerialize["sign_all_scripts"] = src.SignAllScripts
 	}
-	if o.SignAllScripts != nil {
-		toSerialize["sign_all_scripts"] = o.SignAllScripts
-	}
+
 	return json.Marshal(toSerialize)
+}
+
+func (dst *PsbtSignRequest) UnmarshalJSON(data []byte) error {
+	var temp PsbtSignRequest
+	decoder := api.NewStrictDecoder(data)
+
+	if err := decoder.Decode(&temp); err != nil {
+		return err
+	}
+
+	// Check for an empty struct
+	if temp == (PsbtSignRequest{}) {
+		return fmt.Errorf("PSBT sign request cannot be empty")
+	}
+
+	// Copy the valid data to the destination
+	*dst = temp
+	return nil
 }
 
 type NullablePsbtSignRequest struct {


### PR DESCRIPTION
- remove redundant strict decoder
- fix MFA Request Info `expiresAt`.
- unmarshal Babylon Staking Requestion `action`
- strict unmarshal PSBT Sign Request